### PR TITLE
increase conversation limit to 1000 and exclude archived in the call rather the loop

### DIFF
--- a/src/scrape.py
+++ b/src/scrape.py
@@ -49,10 +49,10 @@ def get_thread_replies_cached(client, ts: str, channel_id: str):
 @stub.function(**scraper_kwargs)
 def get_channel_ids(bot_token: str) -> Iterable[str]:
     client = make_slack_client(bot_token)
-    result = client.conversations_list()
+    result = client.conversations_list(exclude_archived=True, limit=1000)
     channels = result["channels"]
     for c in channels:
-        if not c["is_archived"] and not c["is_shared"]:
+        if not c["is_shared"]:
             yield c["id"]
 
 


### PR DESCRIPTION
Per [the Slack docs](https://api.slack.com/methods/conversations.list), I've increased the number of conversations pulled for the bot to train on from 100 (default) to 1,000 (max).

I've also removed the archived channel filter into the `client` call from the subsequent for loop.